### PR TITLE
refactor: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For more information please have a look at the [features](https://thazelart.gith
 
 ### Getting started
 
-Please find all the required information on the [getting stared](https://thazelart.github.io/golang-cli-template/golang-cli-template/getting-started/) section of the documentation.
+Please find all the required information on the [getting started](https://thazelart.github.io/golang-cli-template/golang-cli-template/getting-started/) section of the documentation.
 
 ### Greetings on Pull Requests and Issues
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description


There's a small typo in the "[Getting Started](https://github.com/thazelart/golang-cli-template#getting-started)" section of the README. The hyperlink text reads "stared" instead of "star<code>t</code>ed"

### Summary

in [README](https://github.com/thazelart/golang-cli-template/compare/main...Jonathan-Zollinger:golang-cli-template:refactor/readme-typo?expand=1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)
```diff
- ...stared...
+ ...started...
```


<!--
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## Type of change

- [x] A code change that neither fixes a bug nor adds a feature
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/thazelart/golang-cli-template/blob/main/.github/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
~~I have added tests that prove my fix is effective or that my feature works~~ (Not Applicable)
